### PR TITLE
Add support for "Sec-WebSocket-Protocol" header

### DIFF
--- a/Connection.js
+++ b/Connection.js
@@ -440,17 +440,17 @@ Connection.prototype.answerHandshake = function (lines) {
 		var acceptedProtocols = this.server.acceptedSubprotocols
 		var requestedProtocols = this.requestedProtocols
 
-		var firstProtocol = false
-		requestedProtocols.forEach(function (e) {
-			acceptedProtocols.forEach(function (a) {
-				if (a == e && firstProtocol === false) {
-					firstProtocol = e
-				}
-			})
+		// The earlier a protocol appears in our accepted list, the higher its priority
+		var firstProtocol = acceptedProtocols.length - 1
+		requestedProtocols.forEach(function (protocol) {
+			var positionInAcceptedList = acceptedProtocols.indexOf(protocol)
+
+			if (positionInAcceptedList < firstProtocol) {
+				firstProtocol = positionInAcceptedList
+			}
 		})
 
-		console.log(firstProtocol)
-		this.usedProtocol = firstProtocol
+		this.usedProtocol = acceptedProtocols[firstProtocol]
 		response['Sec-WebSocket-Protocol'] = this.usedProtocol
 	}
 

--- a/Connection.js
+++ b/Connection.js
@@ -416,7 +416,7 @@ Connection.prototype.answerHandshake = function (lines) {
 	// Read protocols
 	var protocols = this.headers['sec-websocket-protocol']
 
-	if (typeof protocols !== "undefined") {
+	if (typeof protocols !== 'undefined') {
 		this.requestedProtocols = protocols
 			.split(",")
 			.map(function(value) {
@@ -450,8 +450,11 @@ Connection.prototype.answerHandshake = function (lines) {
 			}
 		})
 
-		this.usedProtocol = acceptedProtocols[firstProtocol]
-		response['Sec-WebSocket-Protocol'] = this.usedProtocol
+		// Omit header in response if we don't support the protocol
+		if (firstProtocol >= 0) {
+			this.usedProtocol = acceptedProtocols[firstProtocol]
+			response['Sec-WebSocket-Protocol'] = this.usedProtocol
+		}
 	}
 
 	this.socket.write(this.buildRequest('HTTP/1.1 101 Switching Protocols', response))

--- a/Connection.js
+++ b/Connection.js
@@ -436,7 +436,7 @@ Connection.prototype.answerHandshake = function (lines) {
 	}
 
 	// Choose a protocol
-	if (this.server && this.server.acceptedSubprotocols) {
+	if (typeof this.requestedProtocols !== 'undefined' && this.server) {
 		var acceptedProtocols = this.server.acceptedSubprotocols
 		var requestedProtocols = this.requestedProtocols
 

--- a/Server.js
+++ b/Server.js
@@ -61,6 +61,7 @@ function Server(secure, options, callback) {
 		that.emit('error', err)
 	})
 	this.connections = []
+	this.acceptedSubprotocols = []
 
 	// super constructor
 	events.EventEmitter.call(this)
@@ -104,9 +105,7 @@ Server.prototype.listen = function (port, host, callback) {
  * @param {array} [protocols]
  */
 Server.prototype.acceptSubprotocols = function (protocols) {
-	var that = this
-
-	this.acceptedSubprotocols = protocols;
+	this.acceptedSubprotocols = protocols
 
 	return this
 }

--- a/Server.js
+++ b/Server.js
@@ -98,3 +98,15 @@ Server.prototype.listen = function (port, host, callback) {
 
 	return this
 }
+
+/**
+ * Sets the list of supported subprotocols
+ * @param {array} [protocols]
+ */
+Server.prototype.acceptSubprotocols = function (protocols) {
+	var that = this
+
+	this.acceptedSubprotocols = protocols;
+
+	return this
+}


### PR DESCRIPTION
Added a method on the server to list the accepted protocols and implemented logic on the handshake reply to select one of the requested protocols based on the accepted ones.

This is just a basic and rudimentary implementation for a `Sec-WebSocket-Protocol` support (see #29).

I'll gladly add a test and expand the documentation (`README.md`) if this looks good to you.