### PR TITLE
[+] Subprotocols support (Sec-WebSocket-Protocol header), fix #24

### DIFF
--- a/Connection.js
+++ b/Connection.js
@@ -428,7 +428,7 @@ Connection.prototype.answerHandshake = function (lines) {
 	// https://tools.ietf.org/html/rfc6455#page-7
 	if( 'sec-websocket-protocol' in this.headers ){
 		protocol = this.headers['sec-websocket-protocol'];
-		this.protocols = protocol.split(/,|;/);
+		this.protocols = protocol.split(',').map(function(v){return v.trim()});
 		headers2send['Sec-WebSocket-Protocol'] = protocol;
 	} else {
 		// No protocols - empty array

--- a/Connection.js
+++ b/Connection.js
@@ -381,7 +381,7 @@ Connection.prototype.checkHandshake = function (lines) {
  * @private
  */
 Connection.prototype.answerHandshake = function (lines) {
-	var path, key, sha1
+	var path, key, sha1, headers2send, protocol;
 
 	// First line
 	if (lines.length < 6) {
@@ -417,11 +417,25 @@ Connection.prototype.answerHandshake = function (lines) {
 	sha1 = crypto.createHash('sha1')
 	sha1.end(this.key + '258EAFA5-E914-47DA-95CA-C5AB0DC85B11')
 	key = sha1.read().toString('base64')
-	this.socket.write(this.buildRequest('HTTP/1.1 101 Switching Protocols', {
+
+	headers2send = {
 		Upgrade: 'websocket',
 		Connection: 'Upgrade',
 		'Sec-WebSocket-Accept': key
-	}))
+	}
+
+	// subprotocols support
+	// https://tools.ietf.org/html/rfc6455#page-7
+	if( 'sec-websocket-protocol' in this.headers ){
+		protocol = this.headers['sec-websocket-protocol'];
+		this.protocols = protocol.split(/,|;/);
+		headers2send['Sec-WebSocket-Protocol'] = protocol;
+	} else {
+		// No protocols - empty array
+		// No need to check on hi level for null/undefined
+		this.protocols = [];
+	}
+	this.socket.write(this.buildRequest('HTTP/1.1 101 Switching Protocols', headers2send))
 	return true
 }
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ The property `extraHeaders` will be used to add more headers to the HTTP handsha
 
 `callback` will be added as "connect" listener
 
+`protocols` are array of subprotocols for requesting
+
 ## ws.setBinaryFragmentation(bytes)
 Sets the minimum size of a pack of binary data to send in a single frame (default: 512kiB)
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,11 @@ For a connection accepted by a server, it is a string representing the path to w
 ## connection.headers
 Read only map of header names and values. Header names are lower-cased
 
+## connection.protocols
+Array of protocols requested by client. If no protocols are requested - array is empty. Additional resources:
+* [WebSocket Subprotocol Name Registry](http://www.iana.org/assignments/websocket/websocket.xml#subprotocol-name)
+* [The WebSocket Protocol](https://tools.ietf.org/html/rfc6455#page-7)
+
 ## Event: 'close(code, reason)'
 Emitted when the connection is closed by any side
 

--- a/index.js
+++ b/index.js
@@ -43,6 +43,11 @@ exports.connect = function (URL, options, callback) {
 		URL.extraHeaders = options.extraHeaders
 	}
 
+	if (options.hasOwnProperty('protocols')){
+		URL.extraHeaders = URL.extraHeaders || {}
+		URL.extraHeaders['Sec-WebSocket-Protocol'] = options.protocols.join(', ')
+	}
+
 	if (URL.secure) {
 		socket = tls.connect(options)
 	} else {


### PR DESCRIPTION
Subprotocol support fro server and client. 
Server: `conn.protocols` now contain array of protocols requested by client
Client: `options.protocols` - array of protocols for requesting

Fix for #24 