### PR TITLE
Avoid emitting multiple errors

### DIFF
--- a/Connection.js
+++ b/Connection.js
@@ -142,8 +142,9 @@ Connection.prototype.sendText = function (str, callback) {
 			return this.socket.write(frame.createTextFrame(str, !this.server), callback)
 		}
 		this.emit('error', new Error('You can\'t send a text frame until you finish sending binary frames'))
+	} else {
+		this.emit('error', new Error('You can\'t write to a non-open connection'))
 	}
-	this.emit('error', new Error('You can\'t write to a non-open connection'))
 }
 
 /**
@@ -156,8 +157,9 @@ Connection.prototype.beginBinary = function () {
 			return (this.outStream = new OutStream(this, Connection.binaryFragmentation))
 		}
 		this.emit('error', new Error('You can\'t send more binary frames until you finish sending the previous binary frames'))
+	} else {
+		this.emit('error', new Error('You can\'t write to a non-open connection'))
 	}
-	this.emit('error', new Error('You can\'t write to a non-open connection'))
 }
 
 /**
@@ -171,8 +173,9 @@ Connection.prototype.sendBinary = function (data, callback) {
 			return this.socket.write(frame.createBinaryFrame(data, !this.server, true, true), callback)
 		}
 		this.emit('error', new Error('You can\'t send more binary frames until you finish sending the previous binary frames'))
+	} else {
+		this.emit('error', new Error('You can\'t write to a non-open connection'))
 	}
-	this.emit('error', new Error('You can\'t write to a non-open connection'))
 }
 
 /**
@@ -198,8 +201,9 @@ Connection.prototype.send = function (data, callback) {
 Connection.prototype.sendPing = function (data) {
 	if (this.readyState === this.OPEN) {
 		return this.socket.write(frame.createPingFrame(data || '', !this.server))
+	} else {
+		this.emit('error', new Error('You can\'t write to a non-open connection'))
 	}
-	this.emit('error', new Error('You can\'t write to a non-open connection'))
 }
 
 /**

--- a/Connection.js
+++ b/Connection.js
@@ -267,9 +267,12 @@ Connection.prototype.doRead = function () {
  * @private
  */
 Connection.prototype.startHandshake = function () {
-	var str, i, headers, header
-	this.key = (new Buffer((Math.random()*1024).toString(), 'binary')).toString('base64')
-
+	var str, i, key, headers, header
+	key = new Buffer(16)
+	for (i = 0; i < 16; i++) {
+		key[i] = Math.floor(Math.random() * 256)
+	}
+	this.key = key.toString('base64')
 	headers = {
 		Host: this.host,
 		Upgrade: 'websocket',

--- a/Connection.js
+++ b/Connection.js
@@ -267,12 +267,9 @@ Connection.prototype.doRead = function () {
  * @private
  */
 Connection.prototype.startHandshake = function () {
-	var str, i, key, headers, header
-	key = new Buffer(16)
-	for (i = 0; i < 16; i++) {
-		key[i] = Math.floor(Math.random() * 256)
-	}
-	this.key = key.toString('base64')
+	var str, i, headers, header
+	this.key = (new Buffer((Math.random()*1024).toString(), 'binary')).toString('base64')
+
 	headers = {
 		Host: this.host,
 		Upgrade: 'websocket',


### PR DESCRIPTION
1. This PR adds wraps some `emit`s in `else` to avoid emitting two errors in certain edge cases

~~2. This PR speeds up handshake keygen.  Instead of generating 16 random floats and flooring one byte from each of them, generate 1 random float and use that.~~