### PR TITLE
Fix parse error, accept header values separated without space

### DIFF
--- a/Connection.js
+++ b/Connection.js
@@ -387,7 +387,7 @@ Connection.prototype.checkHandshake = function (lines) {
 		return false
 	}
 	if (this.headers.upgrade.toLowerCase() !== 'websocket' ||
-		this.headers.connection.toLowerCase().split(', ').indexOf('upgrade') === -1) {
+		this.headers.connection.toLowerCase().split(/\s*,\s*/).indexOf('upgrade') === -1) {
 		this.emit('error', new Error('Invalid handshake: invalid Upgrade or Connection header'))
 		return false
 	}
@@ -450,7 +450,7 @@ Connection.prototype.answerHandshake = function (lines) {
 		return false
 	}
 	if (this.headers.upgrade.toLowerCase() !== 'websocket' ||
-		this.headers.connection.toLowerCase().split(', ').indexOf('upgrade') === -1) {
+		this.headers.connection.toLowerCase().split(/\s*,\s*/).indexOf('upgrade') === -1) {
 		return false
 	}
 	if (this.headers['sec-websocket-version'] !== '13') {


### PR DESCRIPTION
The following example failed:

    $ socat - TCP:localhost:1234,crnl
    GET / HTTP/1.1
    Connection: Upgrade,Keep-Alive
    Upgrade: websocket
    Sec-WebSocket-Key: hq0S1hpdldRhTHVwXBDPvg==
    Sec-WebSocket-Version: 13
    Host: localhost:1234

    HTTP/1.1 400 Bad Request

    $

but would have worked as expected with

    Connection: Upgrade, Keep-Alive